### PR TITLE
Update package documentation for v0.2.0 API changes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,16 +1,17 @@
 // Package testdbpool provides efficient test database pooling for PostgreSQL integration tests.
 //
 // testdbpool manages a pool of test databases that can be shared across multiple test functions,
-// significantly improving test performance by reusing databases instead of creating and destroying
-// them for each test. Built on top of numpool for resource management, it uses PostgreSQL's
-// template database feature for fast database creation and maintains connection pools for efficiency.
+// significantly improving test performance by reusing template-based database creation instead of
+// running schema migrations for each test. Built on top of numpool for resource management, it uses
+// PostgreSQL's template database feature for fast database creation and the DROP DATABASE strategy
+// for complete isolation between test runs.
 //
 // # Key Features
 //
 //   - Template-based database creation using PostgreSQL's CREATE DATABASE ... TEMPLATE
-//   - Connection pool reuse to eliminate connection establishment overhead
-//   - Concurrent test support with fair resource allocation
-//   - Automatic database reset between test uses
+//   - DROP DATABASE strategy for complete isolation between test runs
+//   - Concurrent test support with excellent resource allocation
+//   - Automatic database cleanup between test uses
 //   - Resource-efficient operation ideal for CI environments
 //   - Cross-package pool sharing using common identifiers
 //
@@ -34,10 +35,6 @@
 //			Pool:         connPool,
 //			SetupTemplate: func(ctx context.Context, conn *pgx.Conn) error {
 //				_, err := conn.Exec(ctx, `CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT)`)
-//				return err
-//			},
-//			ResetDatabase: func(ctx context.Context, pool *pgxpool.Pool) error {
-//				_, err := pool.Exec(ctx, `TRUNCATE TABLE users RESTART IDENTITY`)
 //				return err
 //			},
 //		}
@@ -65,7 +62,7 @@
 //		if err != nil {
 //			t.Fatal(err)
 //		}
-//		defer db.Release(ctx) // Reset and return to pool
+//		defer db.Release(ctx) // Drop database and return resource to pool
 //
 //		// Use the database
 //		_, err = db.Pool().Exec(ctx, "INSERT INTO users (name) VALUES ($1)", "Alice")
@@ -79,10 +76,11 @@
 // testdbpool provides significant performance improvements over traditional approaches:
 //
 //   - Fast database creation through template cloning instead of schema migration
-//   - Efficient cleanup using TRUNCATE instead of database recreation
-//   - Connection pool reuse eliminates connection establishment overhead
+//   - Complete isolation using DROP DATABASE strategy for reliable test separation
+//   - Excellent concurrent test support without resource contention
 //   - Optimal resource utilization in CI and resource-constrained environments
-//   - Reduced load on PostgreSQL server through controlled database pooling
+//   - Superior performance with complex schemas (10+ tables)
+//   - Simplified maintenance with single cleanup strategy
 //
 // # Resource Management
 //

--- a/doc.go
+++ b/doc.go
@@ -10,7 +10,7 @@
 //
 //   - Template-based database creation using PostgreSQL's CREATE DATABASE ... TEMPLATE
 //   - DROP DATABASE strategy for complete isolation between test runs
-//   - Concurrent test support with excellent resource allocation
+//   - Concurrent test support with efficient resource allocation
 //   - Automatic database cleanup between test uses
 //   - Resource-efficient operation ideal for CI environments
 //   - Cross-package pool sharing using common identifiers

--- a/doc.go
+++ b/doc.go
@@ -77,7 +77,7 @@
 //
 //   - Fast database creation through template cloning instead of schema migration
 //   - Complete isolation using DROP DATABASE strategy for reliable test separation
-//   - Excellent concurrent test support without resource contention
+//   - Excellent concurrent test support with minimal resource contention
 //   - Optimal resource utilization in CI and resource-constrained environments
 //   - Superior performance with complex schemas (10+ tables)
 //   - Simplified maintenance with single cleanup strategy


### PR DESCRIPTION
## Summary
- Remove `ResetDatabase` field from example configuration in package documentation
- Update package description to reflect DROP DATABASE strategy
- Emphasize complete isolation and concurrent support benefits
- Update performance benefits section to match current architecture
- Fix code comments to reflect actual behavior (drop vs reset)

## Changes Made
- **Removed outdated API**: Eliminated `ResetDatabase` configuration from code examples
- **Updated strategy description**: Changed from "reusing databases" to "template-based creation with DROP DATABASE isolation"
- **Enhanced feature list**: Updated to emphasize DROP DATABASE strategy and concurrent support
- **Performance benefits**: Updated to reflect complete isolation, concurrent support, and complex schema advantages
- **Comment accuracy**: Changed "Reset and return to pool" to "Drop database and return resource to pool"

## Context
This updates the package-level documentation (`doc.go`) to align with the v0.2.0 breaking changes that removed the `ResetDatabase` configuration field and simplified the library to use DROP DATABASE strategy exclusively.

## Test plan
- [x] Documentation builds correctly
- [x] All tests pass
- [x] Linting and formatting checks pass
- [x] Examples in documentation match current API

🤖 Generated with [Claude Code](https://claude.ai/code)