### PR TITLE
Add DatabaseOwner configuration for database creation

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/yuku/numpool"
+	"github.com/yuku/testdbpool/internal/pgconst"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -316,8 +317,8 @@ func TestIsValidPostgreSQLIdentifier(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isValidPostgreSQLIdentifier(tt.identifier)
-			assert.Equal(t, tt.want, got, "isValidPostgreSQLIdentifier(%q) = %v, want %v", tt.identifier, got, tt.want)
+			got := pgconst.IsValidPostgreSQLIdentifier(tt.identifier)
+			assert.Equal(t, tt.want, got, "pgconst.IsValidPostgreSQLIdentifier(%q) = %v, want %v", tt.identifier, got, tt.want)
 		})
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -134,6 +134,76 @@ func TestConfig_Validate(t *testing.T) {
 			wantErr: true,
 			errMsg:  "pool is required", // First validation error
 		},
+		{
+			name: "valid DatabaseOwner",
+			config: Config{
+				ID:            "test-pool",
+				Pool:          &pgxpool.Pool{},
+				MaxDatabases:  5,
+				SetupTemplate: validSetupTemplate,
+				DatabaseOwner: "my_owner",
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty DatabaseOwner (valid)",
+			config: Config{
+				ID:            "test-pool",
+				Pool:          &pgxpool.Pool{},
+				MaxDatabases:  5,
+				SetupTemplate: validSetupTemplate,
+				DatabaseOwner: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid DatabaseOwner - starts with number",
+			config: Config{
+				ID:            "test-pool",
+				Pool:          &pgxpool.Pool{},
+				MaxDatabases:  5,
+				SetupTemplate: validSetupTemplate,
+				DatabaseOwner: "2invalid",
+			},
+			wantErr: true,
+			errMsg:  "invalid DatabaseOwner: 2invalid",
+		},
+		{
+			name: "invalid DatabaseOwner - contains spaces",
+			config: Config{
+				ID:            "test-pool",
+				Pool:          &pgxpool.Pool{},
+				MaxDatabases:  5,
+				SetupTemplate: validSetupTemplate,
+				DatabaseOwner: "invalid owner",
+			},
+			wantErr: true,
+			errMsg:  "invalid DatabaseOwner: invalid owner",
+		},
+		{
+			name: "invalid DatabaseOwner - contains special chars",
+			config: Config{
+				ID:            "test-pool",
+				Pool:          &pgxpool.Pool{},
+				MaxDatabases:  5,
+				SetupTemplate: validSetupTemplate,
+				DatabaseOwner: "invalid-owner",
+			},
+			wantErr: true,
+			errMsg:  "invalid DatabaseOwner: invalid-owner",
+		},
+		{
+			name: "invalid DatabaseOwner - too long",
+			config: Config{
+				ID:            "test-pool",
+				Pool:          &pgxpool.Pool{},
+				MaxDatabases:  5,
+				SetupTemplate: validSetupTemplate,
+				DatabaseOwner: "this_is_a_very_long_identifier_name_that_exceeds_the_maximum_length",
+			},
+			wantErr: true,
+			errMsg:  "invalid DatabaseOwner: this_is_a_very_long_identifier_name_that_exceeds_the_maximum_length",
+		},
 	}
 
 	for _, tt := range tests {
@@ -216,6 +286,38 @@ func TestConfig_Validate_EdgeCases(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+// TestIsValidPostgreSQLIdentifier tests the PostgreSQL identifier validation function
+func TestIsValidPostgreSQLIdentifier(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		want       bool
+	}{
+		{"valid simple identifier", "myowner", true},
+		{"valid identifier with underscore", "my_owner", true},
+		{"valid identifier starting with underscore", "_owner", true},
+		{"valid identifier with numbers", "owner123", true},
+		{"valid identifier with dollar sign", "owner$test", true},
+		{"valid identifier mixed case", "MyOwner", true},
+		{"empty string", "", false},
+		{"starts with number", "123owner", false},
+		{"contains space", "my owner", false},
+		{"contains hyphen", "my-owner", false},
+		{"contains special chars", "owner@test", false},
+		{"too long (64 chars)", "this_is_a_very_long_identifier_name_that_exceeds_the_maximum_length", false},
+		{"exactly 63 chars (valid)", "this_is_exactly_sixty_three_characters_long_identifier_name_abc", true},
+		{"single character", "a", true},
+		{"single underscore", "_", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidPostgreSQLIdentifier(tt.identifier)
+			assert.Equal(t, tt.want, got, "isValidPostgreSQLIdentifier(%q) = %v, want %v", tt.identifier, got, tt.want)
 		})
 	}
 }

--- a/internal/pgconst/pgconst.go
+++ b/internal/pgconst/pgconst.go
@@ -1,6 +1,27 @@
 package pgconst
 
+import "regexp"
+
 const (
 	// MaxDatabaseNameLength is the maximum length of a database name in PostgreSQL.
 	MaxDatabaseNameLength = 63
+
+	// MaxIdentifierLength is the maximum length of a PostgreSQL identifier.
+	MaxIdentifierLength = 63
 )
+
+var (
+	// PostgreSQL identifier regex pattern: starts with letter/underscore,
+	// followed by letters/digits/underscores/dollar signs, max 63 characters
+	postgresIdentifierRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_$]*$`)
+)
+
+// IsValidPostgreSQLIdentifier checks if the given string is a valid PostgreSQL identifier.
+// PostgreSQL identifiers must start with a letter or underscore, followed by letters,
+// digits, underscores, or dollar signs, and must not exceed 63 characters.
+func IsValidPostgreSQLIdentifier(identifier string) bool {
+	if len(identifier) == 0 || len(identifier) > MaxIdentifierLength {
+		return false
+	}
+	return postgresIdentifierRegex.MatchString(identifier)
+}

--- a/pool.go
+++ b/pool.go
@@ -3,20 +3,14 @@ package testdbpool
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"runtime"
 	"sync"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/yuku/numpool"
+	"github.com/yuku/testdbpool/internal/pgconst"
 	"github.com/yuku/testdbpool/internal/templatedb"
-)
-
-var (
-	// PostgreSQL identifier regex pattern: starts with letter/underscore,
-	// followed by letters/digits/underscores/dollar signs, max 63 characters
-	postgresIdentifierRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_$]*$`)
 )
 
 type Pool struct {
@@ -84,22 +78,12 @@ func (c *Config) Validate() error {
 	}
 
 	if c.DatabaseOwner != "" {
-		if !isValidPostgreSQLIdentifier(c.DatabaseOwner) {
+		if !pgconst.IsValidPostgreSQLIdentifier(c.DatabaseOwner) {
 			return fmt.Errorf("invalid DatabaseOwner: %s", c.DatabaseOwner)
 		}
 	}
 
 	return nil
-}
-
-// isValidPostgreSQLIdentifier checks if the given string is a valid PostgreSQL identifier.
-// PostgreSQL identifiers must start with a letter or underscore, followed by letters,
-// digits, underscores, or dollar signs, and must not exceed 63 characters.
-func isValidPostgreSQLIdentifier(identifier string) bool {
-	if len(identifier) == 0 || len(identifier) > 63 {
-		return false
-	}
-	return postgresIdentifierRegex.MatchString(identifier)
 }
 
 // New creates a new TestDBPool instance with the provided configuration.


### PR DESCRIPTION
## Summary
- Add DatabaseOwner field to Config struct for specifying database owner
- Implement PostgreSQL identifier validation with SQL injection protection  
- Update template and test database creation to use OWNER clause when specified
- Maintain backward compatibility when DatabaseOwner is empty

## Features
✅ **Database Owner Configuration**: New `DatabaseOwner` field in Config struct
✅ **Security**: PostgreSQL identifier validation prevents SQL injection
✅ **Backward Compatibility**: Empty DatabaseOwner maintains existing behavior
✅ **Code Organization**: PostgreSQL utilities moved to internal/pgconst package

## Test Coverage
- Unit tests for Config validation and PostgreSQL identifier validation
- Integration tests verifying database ownership in real PostgreSQL environment
- Tests for various edge cases and error conditions

## Usage Example
```go
pool, err := testdbpool.New(ctx, &testdbpool.Config{
    ID:            "my-pool",
    Pool:          pgxPool,
    MaxDatabases:  5,
    DatabaseOwner: "my_db_owner", // Optional: specify database owner
    SetupTemplate: setupFunc,
})
```

🤖 Generated with [Claude Code](https://claude.ai/code)