### PR TITLE
Update Go version and dependencies

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -41,7 +41,7 @@ func BenchmarkAcquireReleaseCycle(b *testing.B) {
 	pool := createBenchmarkPool(b, ctx, connPool, "basic_benchmark")
 	defer pool.Cleanup()
 
-	for b.Loop() {
+	for range b.N {
 		db, err := pool.Acquire(ctx)
 		if err != nil {
 			b.Fatal(err)
@@ -63,7 +63,7 @@ func BenchmarkWithDataOperations(b *testing.B) {
 	pool := createBenchmarkPool(b, ctx, connPool, "data_benchmark")
 	defer pool.Cleanup()
 
-	for i := 0; b.Loop(); i++ {
+	for i := range b.N {
 		db, err := pool.Acquire(ctx)
 		if err != nil {
 			b.Fatal(err)
@@ -166,7 +166,7 @@ func BenchmarkLargeSchema(b *testing.B) {
 	}
 	defer pool.Cleanup()
 
-	for i := 0; b.Loop(); i++ {
+	for i := range b.N {
 		db, err := pool.Acquire(ctx)
 		if err != nil {
 			b.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/yuku/testdbpool
 
-go 1.24
+go 1.23.0
+
+toolchain go1.24.5
 
 require (
 	github.com/jackc/pgx/v5 v5.7.5

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/stretchr/testify v1.10.0
-	github.com/yuku/numpool v0.4.4
+	github.com/yuku/numpool v0.4.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/yuku/numpool v0.4.4 h1:m7vmVrjR/+sd8l1EdTWo+JmjvKXB+tTJslmMO+TjwNE=
-github.com/yuku/numpool v0.4.4/go.mod h1:s34nTOpsM8yBx517Q3j9/TpDgE1AU27PgREWynJrNkw=
+github.com/yuku/numpool v0.4.5 h1:c1pPdN+UNhPfErNUpDOs8BbVaxiuPdLYjLY5r9KBanw=
+github.com/yuku/numpool v0.4.5/go.mod h1:SmB65ptreWWbPDfIO9fH//pdIpRIBMEnl74K1Wtr4nM=
 golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
 golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=


### PR DESCRIPTION
## Summary
- Downgrade minimum Go version requirement from 1.24 to 1.23.0 for broader compatibility
- Update numpool dependency to v0.4.5
  - For https://github.com/yuku/numpool/pull/19
- Fix benchmark tests to use `for range b.N` instead of Go 1.24+ `b.Loop()`

## Changes
- **go.mod**: Downgraded minimum Go version to 1.23.0 and added toolchain directive
- **benchmark_test.go**: Replaced Go 1.24+ `b.Loop()` with `for range b.N` pattern for Go 1.23.0 compatibility
- **dependencies**: Updated numpool from v0.4.4 to v0.4.5

🤖 Generated with [Claude Code](https://claude.ai/code)